### PR TITLE
httpp: Fix PathValue for ServeMux

### DIFF
--- a/buildinfo/buildinfo.go
+++ b/buildinfo/buildinfo.go
@@ -53,7 +53,7 @@ func init() {
 	}
 }
 
-var Handler = httpp.EmitErrorsFunc(func(w http.ResponseWriter, r *http.Request) error {
+var Handler = func(w http.ResponseWriter, r *http.Request) error {
 	// This handler is often used as startup/liveness probe, for monitoring checks, and possibly
 	// for collecting build information regularly. Disable logging to reduce noise.
 	httpmw.DisableAccessLog(r)
@@ -68,4 +68,4 @@ var Handler = httpp.EmitErrorsFunc(func(w http.ResponseWriter, r *http.Request) 
 		GitCommitDate: GitCommitDate,
 		Version:       Version,
 	})
-})
+}


### PR DESCRIPTION
`httpp.ServeMux` uses `http.ServeMux.Handler` to find the handler to execute. That method does not add path values to the `Request` like `ServeHTTP` does however. See also: https://github.com/golang/go/issues/69623

Instead of `http.ServeMux.Handler`, use `http.ServeMux.ServeHTTP` and return errors from `ServeErrHTTP` of the handler via the `Context`.